### PR TITLE
Update links for Homebrew documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Then, install the program you want with `brew install <formula>`.
 
 You could also install a program with `brew install ctdk/ctdk/<formula>`, or via URL (but doing that way won't get updates) with `brew install https://raw.githubusercontent.com/ctdk/homebrew-ctdk/master/<formula>.rb`.
 
-Read more at the [homebrew tap documentation](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/brew-tap.md).
+Read more at the [homebrew tap documentation](https://docs.brew.sh/Taps).
 
 ## Contents of this tap
 
@@ -19,4 +19,4 @@ Read more at the [homebrew tap documentation](https://github.com/Homebrew/brew/b
 * [`jovian-noise`](https://github.com/ctdk/jovian-noise)
 
 ## Documentation
-`brew help`, `man brew` or check [Homebrew's documentation](https://github.com/Homebrew/brew/tree/master/share/doc/homebrew#readme).
+`brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh/).


### PR DESCRIPTION
Updates Homebrew documentation links with new URLs. The current URLs in this project's README are 404.

Fixes #4.